### PR TITLE
vision logic updates

### DIFF
--- a/src/main/java/frc/robot/vision/Vision.java
+++ b/src/main/java/frc/robot/vision/Vision.java
@@ -133,6 +133,11 @@ public class Vision extends SubsystemBase {
 
     @Override
     public void periodic() {
+        double yaw = Robot.swerve.getRotation().getDegrees();
+        speakerLL.setRobotOrientation(yaw);
+        leftLL.setRobotOrientation(yaw);
+        rightLL.setRobotOrientation(yaw);
+
         try {
             isIntegrating = false;
             // Will NOT run in auto
@@ -147,7 +152,7 @@ public class Vision extends SubsystemBase {
                 if (isAiming && speakerLL.targetInView()) {
                     for (Limelight limelight : limelights) {
                         if (limelight.CAMERA_NAME == speakerLL.CAMERA_NAME) {
-                            filterAndAddVisionMeasurment(limelight);
+                            addFilteredVisionInput(limelight);
                         } else {
                             limelight.sendInvalidStatus("speaker only rejection");
                         }
@@ -155,10 +160,10 @@ public class Vision extends SubsystemBase {
                     }
                 } else {
                     // choose LL with best view of tags and integrate from only that camera
-                    Limelight bestLimelight = getBestLimelight();
+                    Limelight bestLimelight = getBestLimelight(); // exclude rear LL
                     for (Limelight limelight : limelights) {
                         if (limelight.CAMERA_NAME == bestLimelight.CAMERA_NAME) {
-                            filterAndAddVisionMeasurment(bestLimelight);
+                            addFilteredVisionInput(bestLimelight);
                         } else {
                             limelight.sendInvalidStatus("not best rejection");
                         }
@@ -171,17 +176,18 @@ public class Vision extends SubsystemBase {
         }
     }
 
-    private void filterAndAddVisionMeasurment(Limelight ll) {
+    private void addFilteredVisionInput(Limelight ll) {
         double xyStds = 1000;
         double degStds = 1000;
 
         // integrate vision
         if (ll.targetInView()) {
             boolean multiTags = ll.multipleTagsInView();
-            double timeStamp = ll.getVisionPoseTimestamp();
+            double timeStamp = ll.getRawPoseTimestamp();
             double targetSize = ll.getTargetSize();
             Pose3d botpose3D = ll.getRawPose3d();
             Pose2d botpose = botpose3D.toPose2d();
+            Pose2d megaPose2d = ll.getMegaPose2d();
             RawFiducial[] tags = ll.getRawFiducial();
             ChassisSpeeds robotSpeed = Robot.swerve.getVelocity(true);
 
@@ -206,6 +212,7 @@ public class Vision extends SubsystemBase {
             } else if (Math.abs(robotSpeed.omegaRadiansPerSecond) >= 0.5) {
                 // reject if we are rotating more than 0.5 rad/s
                 ll.sendInvalidStatus("rotation rejection");
+                return;
             } else if (Math.abs(botpose3D.getZ()) > 0.25) {
                 // reject if pose is .25 meters in the air
                 ll.sendInvalidStatus("height rejection");
@@ -214,13 +221,8 @@ public class Vision extends SubsystemBase {
                     || Math.abs(botpose3D.getRotation().getY()) > 5) {
                 // reject if pose is 5 degrees titled in roll or pitch
                 ll.sendInvalidStatus("roll/pitch rejection");
+                return;
             }
-            //  else if (poseDifference < Units.inchesToMeters(3)) {
-            //     // reject if pose is very close to robot pose
-            //     isPresent = false;
-            //     ll.logStatus = "proximity rejection";
-            //     return;
-            // }
             /* integrations */
             // if almost stationary and extremely close to tag
             else if (robotSpeed.vxMetersPerSecond + robotSpeed.vyMetersPerSecond <= 0.2
@@ -230,7 +232,7 @@ public class Vision extends SubsystemBase {
                 degStds = 0.1;
             } else if (multiTags && targetSize > 0.05) {
                 ll.sendValidStatus("Multi integration");
-                xyStds = 0.5;
+                xyStds = 0.25;
                 degStds = 8;
                 if (targetSize > 0.09) {
                     ll.sendValidStatus("Strong Multi integration");
@@ -239,7 +241,7 @@ public class Vision extends SubsystemBase {
                 }
             } else if (targetSize > 0.8 && poseDifference < 0.5) {
                 ll.sendValidStatus("Close integration");
-                xyStds = 1.0;
+                xyStds = 0.5;
                 degStds = 16;
             } else if (targetSize > 0.1 && poseDifference < 0.3) {
                 ll.sendValidStatus("Proximity integration");
@@ -263,8 +265,11 @@ public class Vision extends SubsystemBase {
                             VisionConfig.VISION_STD_DEV_X,
                             VisionConfig.VISION_STD_DEV_Y,
                             VisionConfig.VISION_STD_DEV_THETA));
-            Robot.swerve.addVisionMeasurement(botpose, timeStamp);
+
+            Pose2d integratedPose = new Pose2d(megaPose2d.getTranslation(), botpose.getRotation());
+            Robot.swerve.addVisionMeasurement(integratedPose, timeStamp);
         } else {
+            ll.tagStatus = "no tags";
             ll.sendInvalidStatus("no tag found rejection");
         }
     }
@@ -435,14 +440,16 @@ public class Vision extends SubsystemBase {
         Limelight bestLimelight = speakerLL;
         double bestScore = 0;
         for (Limelight limelight : limelights) {
-            double score = 0;
-            // prefer LL with most tags, when equal tag count, prefer LL closer to tags
-            score += limelight.getTagCountInView();
-            score += limelight.getTargetSize();
+            if (limelight.CAMERA_NAME != rearLL.CAMERA_NAME) {
+                double score = 0;
+                // prefer LL with most tags, when equal tag count, prefer LL closer to tags
+                score += limelight.getTagCountInView();
+                score += limelight.getTargetSize();
 
-            if (score > bestScore) {
-                bestScore = score;
-                bestLimelight = limelight;
+                if (score > bestScore) {
+                    bestScore = score;
+                    bestLimelight = limelight;
+                }
             }
         }
         return bestLimelight;

--- a/src/main/java/frc/spectrumLib/swerve/Module.java
+++ b/src/main/java/frc/spectrumLib/swerve/Module.java
@@ -338,7 +338,6 @@ public class Module {
         return m_cancoder;
     }
 
-    // TODO: NEEDS TO BE TESTED
     public void setModuleNeutralMode(NeutralModeValue mode) {
         setDriveNeutralMode(mode);
         setSteerNeutralMode(mode);

--- a/src/main/java/frc/spectrumLib/vision/Limelight.java
+++ b/src/main/java/frc/spectrumLib/vision/Limelight.java
@@ -1,8 +1,8 @@
 package frc.spectrumLib.vision;
 
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.util.Units;
-import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.vision.Vision.VisionConfig;
 import frc.spectrumLib.vision.LimelightHelpers.LimelightResults;
@@ -108,10 +108,16 @@ public class Limelight {
 
     /* ::: Pose Retrieval ::: */
 
-    /** @return the corresponding LL Pose3d for the alliance in DriverStation.java */
+    /** @return the corresponding LL Pose3d (MEGATAG1) for the alliance in DriverStation.java */
     public Pose3d getRawPose3d() {
         return LimelightHelpers.getBotPose3d_wpiBlue(
                 CAMERA_NAME); // 2024: all alliances use blue as 0,0
+    }
+
+    /** @return the corresponding LL Pose3d (MEGATAG2) for the alliance in DriverStation.java */
+    public Pose2d getMegaPose2d() {
+        return LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(CAMERA_NAME)
+                .pose; // 2024: all alliances use blue as 0,0
     }
 
     public boolean hasAccuratePose() {
@@ -130,12 +136,21 @@ public class Limelight {
     }
 
     /**
-     * Returns the timestamp of the pose estimation from the Limelight camera.
+     * Returns the timestamp of the MEGATAG1 pose estimation from the Limelight camera.
      *
      * @return The timestamp of the pose estimation in seconds.
      */
-    public double getVisionPoseTimestamp() {
-        return Timer.getFPGATimestamp() - getPoseLatency();
+    public double getRawPoseTimestamp() {
+        return LimelightHelpers.getBotPoseEstimate_wpiBlue(CAMERA_NAME).timestampSeconds;
+    }
+
+    /**
+     * Returns the timestamp of the MEGATAG2 pose estimation from the Limelight camera.
+     *
+     * @return The timestamp of the pose estimation in seconds.
+     */
+    public double getMegaPoseTimestamp() {
+        return LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(CAMERA_NAME).timestampSeconds;
     }
 
     /**
@@ -143,6 +158,7 @@ public class Limelight {
      *
      * @return The latency of the pose estimation in seconds.
      */
+    @Deprecated(forRemoval = true)
     public double getPoseLatency() {
         return Units.millisecondsToSeconds(LimelightHelpers.getBotPose_wpiBlue(CAMERA_NAME)[6]);
     }
@@ -190,6 +206,15 @@ public class Limelight {
     /** @param pipelineIndex use pipeline indexes in {@link VisionConfig} //TODO: come back */
     public void setLimelightPipeline(int pipelineIndex) {
         LimelightHelpers.setPipelineIndex(CAMERA_NAME, pipelineIndex);
+    }
+
+    /** */
+    public void setRobotOrientation(double degrees) {
+        LimelightHelpers.SetRobotOrientation(CAMERA_NAME, degrees, 0, 0, 0, 0, 0);
+    }
+
+    public void setRobotOrientation(double degrees, double angularRate) {
+        LimelightHelpers.SetRobotOrientation(CAMERA_NAME, degrees, angularRate, 0, 0, 0, 0);
     }
 
     /**


### PR DESCRIPTION
Vision
- exclude rear from integrations
- update mega pose orientations using overall pose
- increased position trust by 50% but kept conditions the same (i think we can almost redo how we do pose after states)
- use old pose for rotation and mega pose for position

Limelight
- added getter/setter from Lib